### PR TITLE
Add quotes to UPDATE_SOURCESETS in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ gradlew -PUPDATE_CLASSNAMES=true updateClassnames
 ```
 By default, this will only apply to the `main` sourceset. 
 If you have an `api` sourceset or other sourcesets, you can add these as well using the `UPDATE_SOURCESETS` property.
-This is a semicolon-separated list that can be defined, for example, as `-PUPDATE_SOURCESETS=main;api` and would be inserted into the above command.
+This is a semicolon-separated list that can be defined, for example, as `-PUPDATE_SOURCESETS="main;api"` and would be inserted into the above command.
 
 If you are **backporting** a mod from 1.17 or later to 1.16 or earlier, add `-PREVERSED=true`. This will convert the classnames from Mojang back to MCP.
 


### PR DESCRIPTION
At least on Linux/bash the quotes are necessary. Otherwise it is interpreted as a separate command.
Not really important, more of a convenience fix

Also, thank you for creating this helpful remapper tool! :)
If you prefer it, feel free to manually add the quote. PR was just the easiest way for me